### PR TITLE
Enhancement: command timeout specific exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Recommended:
 $ pip install git+https://github.com/bucknerns/sshaolin
 ```
 
+## Unit Tests
+
+* Must be running an SSH server at localhost:22
+* Must have Passwordsless SSH Auth to localhost
+```python
+$ tox
+```
+
 ## Requirements:
 
 * [paramiko](https://github.com/paramiko/paramiko)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ class Tox(TestCommand):
         errno = tox.cmdline(self.test_args)
         sys.exit(errno)
 
+
 setup(
     name='sshaolin',
     version='0.0.4',

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -47,6 +47,7 @@ def import_ssh_test():
     from tests import ssh_run_ls_on_import
     ssh_run_ls_on_import
 
+
 try:
     import_ssh_test()
     test_pass = True

--- a/tests/test_ssh_localhost.py
+++ b/tests/test_ssh_localhost.py
@@ -1,3 +1,4 @@
+from sshaolin.client import CommandOperationTimeOut
 from tests.base_test import BaseTestCase, test_pass
 
 
@@ -19,6 +20,17 @@ class TestLocalhost(BaseTestCase):
         self.assertFalse(resp.stderr)
         self.assertNotEqual(resp.stdout, resp2.stdout)
         shell.close()
+
+    def test_command_timeout(self):
+        timeout = 1
+        command = 'sleep 300'
+
+        shell = self.client.create_shell(timeout=timeout)
+        with self.assertRaises(CommandOperationTimeOut) as exc_timeout:
+            shell.execute_command(command)
+
+            self.assertEqual(exc_timeout.timeout, timeout)
+            self.assertEqual(exc_timeout.command, command)
 
     def test_create_sftp(self):
         sftp = self.client.create_sftp()

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ commands=nosetests
 [testenv:py34]
 commands=nosetests
 
+[testenv:py35]
+commands=nosetests
+
 [testenv:pep8]
 commands=flake8
 


### PR DESCRIPTION
- Enhancement: Use a custom exception when terminating b/c of
  command operational timeout expiration. It's a subclass of
  socket.timeout to maintain backwards compatibility but also
  adds some additional contextual information. Added a unit
  test to verify it.
- Bug Fix: pep8 compliance
- Bug Fix: py35 support in tox.ini
- Bug Fix: Added unit test docs to README.md


NOTE: The overloading of `socket.timeout` for when commands fail to execute within a given boundary makes it difficult to determine if the failure is b/c of network conditions or b/c of the command itself. This adds a specific (and backwards compatible) exception for when the command fails to execute within the time boundary, unit test provided.